### PR TITLE
Remove comparison of byte array JSON representation in ViewTest

### DIFF
--- a/core/data/src/test/java/uk/gov/gchq/gaffer/data/elementdefinition/view/ViewTest.java
+++ b/core/data/src/test/java/uk/gov/gchq/gaffer/data/elementdefinition/view/ViewTest.java
@@ -408,9 +408,6 @@ public class ViewTest extends JSONSerialisationTest<View> {
         final byte[] viewJson = view.toCompactJson();
         final byte[] cloneJson = clone.toCompactJson();
 
-        // Check that JSON representations of the objects are equal
-        assertThat(cloneJson).containsExactly(viewJson);
-
         final View viewFromJson = new View.Builder().json(viewJson).build();
         final View cloneFromJson = new View.Builder().json(cloneJson).build();
 


### PR DESCRIPTION
### Problem Description
`uk.gov.gchq.gaffer.data.elementdefinition.view.ViewTest.shouldCreateAnIdenticalObjectWhenCloned` may fail when comparing byte array JSON representations because JSON entries are unordered and the result from `View.toCompactJson()` can vary.
### Reproduce
- Environment setup: Maven 3.6.3 and Java 1.8.0_422
- Clone the repo
```
git clone https://github.com/gchq/Gaffer.git
cd Gaffer
git rev-parse HEAD
git checkout 789a898ccc5db57226109233b22bb6b5180c46c0
```
- Compile and run test with the [Nondex](https://github.com/TestingResearchIllinois/nondex) tool
```
mvn install -pl core/data -am -DskipTests
mvn -pl core/data edu.illinois:nondex-maven-plugin:2.1.7:nondex -Dtest=uk.gov.gchq.gaffer.data.elementdefinition.view.ViewTest#shouldCreateAnIdenticalObjectWhenCloned
```
- Test failure
<img width="913" alt="image" src="https://github.com/user-attachments/assets/e953016e-25d7-4fb6-bc23-ec9b79468143">

### Proposed Fix
Remove the Assert for byte array JSON representations. Since the test function should check if the cloned object equals the original one, testing on JSON objects and ones reconstructed from byte arrays would be sufficient.